### PR TITLE
Reduce dependencies on OTP apps

### DIFF
--- a/lib/whenwhere.ex
+++ b/lib/whenwhere.ex
@@ -5,9 +5,6 @@ defmodule Whenwhere do
 
   @default_whenwhere_url "whenwhere.nerves-project.org/"
   def ask(protocol \\ "http://") do
-    Application.ensure_started(:inets)
-    Application.ensure_started(:sasl)
-
     request_headers = [
       {~c"user-agent", ~c"whenwhere"},
       {~c"content-type", ~c"application/x-erlang-binary"}

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Whenwhere.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger, :sasl, :inets, :ssl]
+      extra_applications: [:inets, :ssl]
     ]
   end
 


### PR DESCRIPTION
This also removes the `Application.ensure_started/1` calls since the
hard dependencies on `:inets` and `:ssl` will make sure they're around.
